### PR TITLE
srtp: Fix cryptocontext constructors

### DIFF
--- a/srtp/CryptoContext.cpp
+++ b/srtp/CryptoContext.cpp
@@ -49,7 +49,7 @@ CryptoContext::CryptoContext( uint32_t ssrc,
         roc(roc),guessed_roc(0),s_l(0),key_deriv_rate(key_deriv_rate),
         replay_window(0),
         master_key_srtp_use_nb(0), master_key_srtcp_use_nb(0), seqNumSet(false),
-        cipher(NULL), f8Cipher(NULL)
+        macCtx(NULL), cipher(NULL), f8Cipher(NULL)
 {
     this->ealg = ealg;
     this->aalg = aalg;

--- a/srtp/CryptoContextCtrl.cpp
+++ b/srtp/CryptoContextCtrl.cpp
@@ -48,7 +48,7 @@ CryptoContextCtrl::CryptoContextCtrl(uint32_t ssrc,
                                 int32_t skeyl,
                                 int32_t tagLength):
 ssrcCtx(ssrc),using_mki(false),mkiLength(0),mki(NULL),
-replay_window(0), cipher(NULL), f8Cipher(NULL)
+replay_window(0), macCtx(NULL), cipher(NULL), f8Cipher(NULL)
 {
     this->ealg = ealg;
     this->aalg = aalg;


### PR DESCRIPTION
macCtx should be initialized explicitly inside constructor to NULL,
otherwise it will be initialized by random value, destructor
will pass (macCtx != NULL) check and will try to deallocate that junk.
