### PR TITLE
Fix for android build

### DIFF
--- a/zrtp/ZIDCacheFile.cpp
+++ b/zrtp/ZIDCacheFile.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <crypto/zrtpDH.h>
 


### PR DESCRIPTION
The unistd.h seems required to use unlink on android.
