### PR TITLE
Impropper initialization of RNG on Windows

### DIFF
--- a/cryptcommon/ZrtpRandom.cpp
+++ b/cryptcommon/ZrtpRandom.cpp
@@ -173,12 +173,7 @@ size_t ZrtpRandom::getSystemSeed(uint8_t *seed, size_t length)
     else
         return num;
 #else
-    clock_t c = clock();
-    if (length > sizeof(c))
-    {
-        memcpy(seed, &c, sizeof(c));
-        num = sizeof(c);
-    }
+#error This random number generator can not be used on Windows platform without seeding!
 #endif
     return num;
 }


### PR DESCRIPTION
In the original random number generator I was able to reproduce the same random numbers 
on Windows in Debug mode,

On Windows platform when using GNU ZRTP library in standalone, without
OpenSSL, the integrated random number generator is not initializated
with enought entropy. This code will add entropy using the system timers

https://en.wikipedia.org/wiki/Clock_drift#Random_number_generators
