### PR TITLE
Fixed compilation warning

### DIFF
--- a/zrtp/libzrtpcpp/ZrtpCWrapper.h
+++ b/zrtp/libzrtpcpp/ZrtpCWrapper.h
@@ -565,7 +565,7 @@ extern "C"
      * @returns
      *      Pointer to the ZrtpContext
      */
-    ZrtpContext* zrtp_CreateWrapper();
+    ZrtpContext* zrtp_CreateWrapper(void);
 
     /**
      * Initialize the ZRTP protocol engine.


### PR DESCRIPTION
"warning: function declaration isn't a prototype"
