### PR TITLE
Fix OpenSSL related compilation warnings on OSX

### DIFF
--- a/srtp/crypto/openssl/SrtpSymCrypto.cpp
+++ b/srtp/crypto/openssl/SrtpSymCrypto.cpp
@@ -43,6 +43,11 @@
 #include <stdio.h>
 #include <common/osSpecifics.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 SrtpSymCrypto::SrtpSymCrypto(int algo):key(NULL), algorithm(algo) {
 }
 
@@ -313,3 +318,6 @@ int SrtpSymCrypto::processBlock(F8_CIPHER_CTX *f8ctx, const uint8_t* in, int32_t
     return length;
 }
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/srtp/crypto/openssl/hmac.cpp
+++ b/srtp/crypto/openssl/hmac.cpp
@@ -37,6 +37,11 @@
 #include <openssl/hmac.h>
 #include <crypto/hmac.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void hmac_sha1(uint8_t * key, int32_t key_length,
                const uint8_t* data, uint32_t data_length,
                uint8_t* mac, int32_t* mac_length )
@@ -111,3 +116,7 @@ void freeSha1HmacContext(void* ctx)
         free(ctx);
     }
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/InitializeOpenSSL.cpp
+++ b/zrtp/crypto/openssl/InitializeOpenSSL.cpp
@@ -35,6 +35,12 @@
 #undef  const
 #endif
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+
 static void threadLockSetup(void);
 static void threadLockCleanup(void);
 static void myLockingCallback(int, int, const char *, int);
@@ -235,3 +241,6 @@ static unsigned long pthreads_thread_id(void)
 }
 */
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/aesCFB.cpp
+++ b/zrtp/crypto/openssl/aesCFB.cpp
@@ -40,8 +40,12 @@
 
 #include <zrtp/crypto/aesCFB.h>
 
-// extern void initializeOpenSSL();
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
+// extern void initializeOpenSSL();
 
 void aesCfbEncrypt(uint8_t* key, int32_t keyLength, uint8_t* IV, uint8_t *data,
                    int32_t dataLength)
@@ -87,3 +91,7 @@ void aesCfbDecrypt(uint8_t* key, int32_t keyLength, uint8_t* IV, uint8_t *data,
     AES_cfb128_encrypt(data, data, dataLength, &aesKey,
                        IV, &usedBytes, AES_DECRYPT);
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/hmac256.cpp
+++ b/zrtp/crypto/openssl/hmac256.cpp
@@ -38,6 +38,11 @@
 #include <openssl/hmac.h>
 #include <crypto/hmac256.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void hmac_sha256(uint8_t* key, uint32_t key_length,
 		uint8_t* data, int32_t data_length,
                 uint8_t* mac, uint32_t* mac_length)
@@ -65,3 +70,7 @@ void hmac_sha256(uint8_t* key, uint32_t key_length,
     *mac_length = tmp;
     HMAC_CTX_cleanup( &ctx );
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/hmac384.cpp
+++ b/zrtp/crypto/openssl/hmac384.cpp
@@ -38,6 +38,11 @@
 #include <openssl/hmac.h>
 #include <zrtp/crypto/hmac256.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void hmac_sha384(uint8_t* key, uint32_t key_length, uint8_t* data, int32_t data_length, uint8_t* mac, uint32_t* mac_length)
 {
     unsigned int tmp;
@@ -63,3 +68,7 @@ void hmac_sha384(uint8_t* key, uint32_t key_length,
     *mac_length = tmp;
     HMAC_CTX_cleanup( &ctx );
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/sha256.cpp
+++ b/zrtp/crypto/openssl/sha256.cpp
@@ -40,6 +40,11 @@
 
 #include <crypto/sha256.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void sha256(unsigned char *data, unsigned int data_length,
 	    unsigned char *digest )
 {
@@ -112,3 +117,7 @@ void sha256Ctx(void* ctx, unsigned char* dataChunks[],
         dataChunkLength++;
     }
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/sha384.cpp
+++ b/zrtp/crypto/openssl/sha384.cpp
@@ -40,6 +40,11 @@
 
 #include <crypto/sha384.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 void sha384(unsigned char *data, unsigned int data_length,
 	    unsigned char *digest )
 {
@@ -113,3 +118,7 @@ void sha384Ctx(void* ctx, unsigned char* dataChunks[],
         dataChunkLength++;
     }
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif

--- a/zrtp/crypto/openssl/zrtpDH.cpp
+++ b/zrtp/crypto/openssl/zrtpDH.cpp
@@ -49,6 +49,11 @@
 #include <zrtp/crypto/zrtpDH.h>
 #include <zrtp/libzrtpcpp/ZrtpTextData.h>
 
+#if defined(__APPLE__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 // extern void initializeOpenSSL();
 
 static BIGNUM* bnP2048 = NULL;
@@ -416,6 +421,10 @@ const char* ZrtpDH::getDHtype()
     }
     return NULL;
 }
+
+#if defined(__APPLE__)
+#  pragma GCC diagnostic pop
+#endif
 
 /** EMACS **
  * Local variables:


### PR DESCRIPTION
Apple deprecated OpenSSL in OSX 10.7, so compiling with OpenSSL
generated a ton of warnings, suppress those.
