### PR TITLE
Added support for OpenSSL >= 1.1.0.

### DIFF
--- a/srtp/CryptoContext.h
+++ b/srtp/CryptoContext.h
@@ -421,7 +421,11 @@ private:
     typedef union _hmacCtx {
         SkeinCtx_t       hmacSkeinCtx;
 #ifdef ZRTP_OPENSSL
+	#if OPENSSL_VERSION_NUMBER < 0x10100000L
         HMAC_CTX         hmacSha1Ctx;
+	#else
+		HMAC_CTX *		hmacSha1Ctx;
+	#endif
 #else
         hmacSha1Context  hmacSha1Ctx;
 #endif

--- a/srtp/crypto/openssl/hmac.cpp
+++ b/srtp/crypto/openssl/hmac.cpp
@@ -50,23 +50,42 @@ void hmac_sha1( uint8_t* key, int32_t key_length,
                 const uint8_t* data_chunks[],
                 uint32_t data_chunck_length[],
                 uint8_t* mac, int32_t* mac_length ) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX ctx;
     HMAC_CTX_init(&ctx);
     HMAC_Init_ex(&ctx, key, key_length, EVP_sha1(), NULL);
+#else
+	HMAC_CTX* ctx;
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex(ctx, key, key_length, EVP_sha1(), NULL);
+#endif
     while (*data_chunks) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         HMAC_Update(&ctx, *data_chunks, *data_chunck_length);
+#else
+		HMAC_Update(ctx, *data_chunks, *data_chunck_length);
+#endif
         data_chunks ++;
         data_chunck_length ++;
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_Final(&ctx, mac, reinterpret_cast<uint32_t*>(mac_length));
     HMAC_CTX_cleanup(&ctx);
+#else
+	HMAC_Final(ctx, mac, reinterpret_cast<uint32_t*>(mac_length));
+	HMAC_CTX_free( ctx );
+#endif
 }
 
 void* createSha1HmacContext(uint8_t* key, int32_t key_length)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX* ctx = (HMAC_CTX*)malloc(sizeof(HMAC_CTX));
 
     HMAC_CTX_init(ctx);
+#else
+	HMAC_CTX* ctx = HMAC_CTX_new();
+#endif
     HMAC_Init_ex(ctx, key, key_length, EVP_sha1(), NULL);
     return ctx;
 }
@@ -75,7 +94,11 @@ void* initializeSha1HmacContext(void* ctx, uint8_t* key, int32_t keyLength)
 {
     HMAC_CTX *pctx = (HMAC_CTX*)ctx;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX_init(pctx);
+#else
+	HMAC_CTX_reset(pctx);
+#endif
     HMAC_Init_ex(pctx, key, keyLength, EVP_sha1(), NULL);
     return pctx;
 }
@@ -85,9 +108,9 @@ void hmacSha1Ctx(void* ctx, const uint8_t* data, uint32_t data_length,
 {
     HMAC_CTX* pctx = (HMAC_CTX*)ctx;
 
-    HMAC_Init_ex(pctx, NULL, 0, NULL, NULL );
-    HMAC_Update(pctx, data, data_length );
-    HMAC_Final(pctx, mac, reinterpret_cast<uint32_t*>(mac_length) );
+    HMAC_Init_ex( pctx, NULL, 0, NULL, NULL );
+    HMAC_Update( pctx, data, data_length );
+    HMAC_Final( pctx, mac, reinterpret_cast<uint32_t*>(mac_length) );
 }
 
 void hmacSha1Ctx(void* ctx, const uint8_t* data[], uint32_t data_length[],
@@ -95,19 +118,23 @@ void hmacSha1Ctx(void* ctx, const uint8_t* data[], uint32_t data_length[],
 {
     HMAC_CTX* pctx = (HMAC_CTX*)ctx;
 
-    HMAC_Init_ex(pctx, NULL, 0, NULL, NULL );
+    HMAC_Init_ex( pctx, NULL, 0, NULL, NULL );
     while (*data) {
-        HMAC_Update(pctx, *data, *data_length);
+        HMAC_Update( pctx, *data, *data_length );
         data++;
         data_length++;
     }
-    HMAC_Final(pctx, mac, reinterpret_cast<uint32_t*>(mac_length) );
+    HMAC_Final( pctx, mac, reinterpret_cast<uint32_t*>(mac_length) );
 }
 
 void freeSha1HmacContext(void* ctx)
 {
     if (ctx) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         HMAC_CTX_cleanup((HMAC_CTX*)ctx);
-        free(ctx);
+		free(ctx);
+#else
+		HMAC_CTX_free((HMAC_CTX*)ctx);
+#endif
     }
 }

--- a/zrtp/crypto/openssl/hmac256.cpp
+++ b/zrtp/crypto/openssl/hmac256.cpp
@@ -53,15 +53,33 @@ void hmac_sha256(uint8_t* key, uint32_t key_length,
                  uint8_t* mac, uint32_t* mac_length )
 {
     unsigned int tmp;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX ctx;
     HMAC_CTX_init( &ctx );
     HMAC_Init_ex( &ctx, key, key_length, EVP_sha256(), NULL );
+#else
+	HMAC_CTX * ctx;
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex( ctx, key, key_length, EVP_sha256(), NULL );
+#endif
     while( *data_chunks ){
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
       HMAC_Update( &ctx, *data_chunks, *data_chunck_length );
+#else
+	  HMAC_Update( ctx, *data_chunks, *data_chunck_length );
+#endif
       data_chunks ++;
       data_chunck_length ++;
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_Final( &ctx, mac, &tmp);
+#else
+	HMAC_Final( ctx, mac, &tmp);
+#endif
     *mac_length = tmp;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX_cleanup( &ctx );
+#else
+	HMAC_CTX_free( ctx );
+#endif
 }

--- a/zrtp/crypto/openssl/hmac384.cpp
+++ b/zrtp/crypto/openssl/hmac384.cpp
@@ -51,15 +51,33 @@ void hmac_sha384(uint8_t* key, uint32_t key_length,
                  uint8_t* mac, uint32_t* mac_length )
 {
     unsigned int tmp;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX ctx;
-    HMAC_CTX_init( &ctx );
-    HMAC_Init_ex( &ctx, key, key_length, EVP_sha384(), NULL );
+	HMAC_CTX_init( &ctx );
+	HMAC_Init_ex( &ctx, key, key_length, EVP_sha384(), NULL );
+#else
+	HMAC_CTX * ctx;
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex( ctx, key, key_length, EVP_sha384(), NULL );
+#endif
     while( *data_chunks ){
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
       HMAC_Update( &ctx, *data_chunks, *data_chunck_length );
+#else
+      HMAC_Update( ctx, *data_chunks, *data_chunck_length );
+#endif
       data_chunks ++;
       data_chunck_length ++;
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_Final( &ctx, mac, &tmp);
+#else
+	HMAC_Final( ctx, mac, &tmp);
+#endif
     *mac_length = tmp;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX_cleanup( &ctx );
+#else
+	HMAC_CTX_free( ctx );
+#endif
 }


### PR DESCRIPTION
In openssl v1.1.0, lots of structures were hidden and one now has to communicate with API through opaque pointers.

https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes

This PR adds support for openssl versions >=1.1.0. However, it does still support versions below. 

