### PR TITLE
License ZRTPCPP Tivi glue under Apache License 2.0

### DIFF
--- a/clients/tivi/CMakeLists.txt
+++ b/clients/tivi/CMakeLists.txt
@@ -1,3 +1,21 @@
+#
+# Copyright (c) 2019 Silent Circle.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# @author Werner Dittmann <Werner.Dittmann@t-online.de>
+
 cmake_minimum_required (VERSION 2.6)
 
 # setup the Thread include and lib

--- a/clients/tivi/CtZrtpCallback.h
+++ b/clients/tivi/CtZrtpCallback.h
@@ -1,7 +1,20 @@
 /*
- * Tivi client glue code for ZRTP.
- * Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Tivi client glue code for ZRTP.
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>
  */

--- a/clients/tivi/CtZrtpSession.cpp
+++ b/clients/tivi/CtZrtpSession.cpp
@@ -1,7 +1,20 @@
 /*
- * Tivi client glue code for ZRTP.
- * Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Tivi client glue code for ZRTP.
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>
  */

--- a/clients/tivi/CtZrtpSession.h
+++ b/clients/tivi/CtZrtpSession.h
@@ -1,7 +1,20 @@
 /*
- * Tivi client glue code for ZRTP.
- * Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Tivi client glue code for ZRTP.
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>
  */

--- a/clients/tivi/CtZrtpStream.cpp
+++ b/clients/tivi/CtZrtpStream.cpp
@@ -1,7 +1,20 @@
 /*
- * Tivi client glue code for ZRTP.
- * Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Tivi client glue code for ZRTP.
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>
  */

--- a/clients/tivi/CtZrtpStream.h
+++ b/clients/tivi/CtZrtpStream.h
@@ -1,7 +1,20 @@
 /*
- * Tivi client glue code for ZRTP.
- * Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Tivi client glue code for ZRTP.
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>
  */

--- a/clients/tivi/android/jni/Android.mk
+++ b/clients/tivi/android/jni/Android.mk
@@ -1,5 +1,18 @@
 #
-# Copyright (c) 2013 Slient Circle LLC.  All rights reserved.
+# Copyright (c) 2019 Silent Circle.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 #
 # @author Werner Dittmann <Werner.Dittmann@t-online.de>
 #

--- a/clients/tivi/android/jni/Application.mk
+++ b/clients/tivi/android/jni/Application.mk
@@ -1,5 +1,18 @@
 #
-# Copyright (c) 2012 Slient Circle LLC.  All rights reserved.
+# Copyright (c) 2019 Silent Circle.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 #
 # @author Werner Dittmann <Werner.Dittmann@t-online.de>
 #

--- a/clients/tivi/sdesTestdriver.cpp
+++ b/clients/tivi/sdesTestdriver.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
  * Test program for tivi interface
  */
 #include <stdio.h>

--- a/clients/tivi/swigJava/SessionTest.java
+++ b/clients/tivi/swigJava/SessionTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2013 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>

--- a/clients/tivi/swigJava/sessionTest.i
+++ b/clients/tivi/swigJava/sessionTest.i
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2013 Slient Circle LLC.  All rights reserved.
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  *
  * @author Werner Dittmann <Werner.Dittmann@t-online.de>

--- a/clients/tivi/testdriver.cpp
+++ b/clients/tivi/testdriver.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) 2019 Silent Circle.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
  * Test program for tivi interface
  */
 #include <stdio.h>


### PR DESCRIPTION
With this commit, we release the ZRTPCPP source code files to which
Silent Circle holds copyright under the terms of the Apache License
Version 2.0.